### PR TITLE
Update ETH cost per token in PlayPage: adjust cost from 0.0000055 to …

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -356,7 +356,7 @@ export default function PlayPage() {
 
 
     // Calculate ETH cost based on token amount (0.0000055 ETH per token)
-    const ethCostPerToken = 0.0000055;
+    const ethCostPerToken = 0.0000022; //0.0000022ETH per token
     const totalEthCost = amount * ethCostPerToken;
     
     // Convert to Wei


### PR DESCRIPTION
…0.0000022 ETH per token for improved pricing accuracy in transactions.